### PR TITLE
fix: Change default return schema type from 'Any' to 'object' in OpenAPI operation parser

### DIFF
--- a/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
+++ b/src/google/adk/tools/openapi_tool/openapi_spec_parser/operation_parser.py
@@ -165,7 +165,7 @@ class OperationParser:
     """Returns a Parameter object representing the return type."""
     responses = self._operation.responses or {}
     # Default to Any if no 2xx response or if schema is missing
-    return_schema = Schema(type='Any')
+    return_schema = Schema(type='object')
 
     # Take the 20x response with the smallest response code.
     valid_codes = list(


### PR DESCRIPTION
## Summary

This PR fixes the default return schema type in the OpenAPI operation parser from 'Any' to 'object'.

## Changes Made

- Updated  in  to use 'object' as the default return type instead of 'Any'
- This change provides better type consistency for OpenAPI operations
- Improves schema validation and type inference

## Testing

- Ran the API Hub toolset tests successfully
- All 14 tests in  passed
- No breaking changes expected

## Impact

- Better type safety for OpenAPI operations
- More consistent schema handling
- Improved developer experience with better type inference

This is a minimal change that improves the robustness of the OpenAPI toolset without breaking existing functionality.